### PR TITLE
Remove coloredlogs from the interface

### DIFF
--- a/src/rail/estimation/algos/delightPZ.py
+++ b/src/rail/estimation/algos/delightPZ.py
@@ -24,15 +24,12 @@ import qp
 import os
 import errno
 
-import coloredlogs
 import logging
 
 # Filters and SED
 
 # Create a logger object.
 logger = logging.getLogger(__name__)
-
-coloredlogs.install(level='DEBUG', logger=logger, fmt='%(asctime)s,%(msecs)03d %(programname)s %(name)s[%(process)d] %(levelname)s %(message)s')
 
 
 class Inform_DelightPZ(CatInformer):


### PR DESCRIPTION
rail_delight uses the coloredlogs package to make its logs more readable. Unfortunately there's [a bug in coloredlogs](https://github.com/xolox/python-coloredlogs/issues/18#issuecomment-786025433) that means that this causes the global log level to be set to DEBUG. This is especially annoying for matplotlib which can the start listing all the fonts it finds on your system.

This removes the call to coloredlogs.